### PR TITLE
Add `getVolunteerPlatformSignup` logic

### DIFF
--- a/backend/typescript/services/implementations/volunteerPlatformSignup.ts
+++ b/backend/typescript/services/implementations/volunteerPlatformSignup.ts
@@ -1,19 +1,41 @@
+import { Prisma, volunteerPlatformSignUp } from "@prisma/client";
+import prisma from "../../prisma";
 import IVolunteerPlatformSignup from "../interfaces/volunteerPlatformSignup";
+import logger from "../../utilities/logger";
+import { getErrorMessage } from "../../utilities/errorUtils";
 
-class VolunteerPlatformSignup implements IVolunteerPlatformSignup{
-    // ADD PARAMETER AND RETURN TYPES IN NEXT TICKET
+const Logger = logger(__filename);
 
-    async getVolunteerPlatformSignup(): Promise<void> {
-        // Implementation to be added
+class VolunteerPlatformSignup implements IVolunteerPlatformSignup {
+  async getVolunteerPlatformSignup(
+    adminId: string,
+  ): Promise<volunteerPlatformSignUp[]> {
+    let volunteerSignUps: volunteerPlatformSignUp[];
+
+    try {
+      volunteerSignUps = await prisma.volunteerPlatformSignUp.findMany({
+        where: {
+          adminId,
+        },
+      });
+    } catch (error) {
+      Logger.error(
+        `Failed to get volunteer platform signups. Reason = ${getErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
     }
+    return volunteerSignUps;
+  }
 
-    async postVolunteerPlatformSignup(): Promise<void> {
-        // Implementation to be added
-    }
+  async postVolunteerPlatformSignup(): Promise<void> {
+    // Implementation to be added
+  }
 
-    async editVolunteerPlatformSignup(): Promise<void> {
-        // Implementation to be added
-    }
+  async editVolunteerPlatformSignup(): Promise<void> {
+    // Implementation to be added
+  }
 
 }
 

--- a/backend/typescript/services/interfaces/volunteerPlatformSignup.ts
+++ b/backend/typescript/services/interfaces/volunteerPlatformSignup.ts
@@ -1,21 +1,24 @@
-interface IVolunteerPlatformSignup {
-    // ADD PARAMETER AND RETURN TYPES IN NEXT TICKET
+import { volunteerPlatformSignUp } from "@prisma/client";
 
-   /**
+interface IVolunteerPlatformSignup {
+  // ADD PARAMETER AND RETURN TYPES IN NEXT TICKET
+
+  /**
    * Gets volunteer signup
    */
-   getVolunteerPlatformSignup(): Promise<void>;
+  getVolunteerPlatformSignup(
+    adminId: string,
+  ): Promise<volunteerPlatformSignUp[]>;
 
-   /**
+  /**
    * Posts volunteer signup
-   */    
-    postVolunteerPlatformSignup(): Promise<void>
+   */
+  postVolunteerPlatformSignup(): Promise<void>;
 
-   /**
+  /**
    * Edits volunteer signup
    */
-    editVolunteerPlatformSignup(): Promise<void>
-
+  editVolunteerPlatformSignup(): Promise<void>;
 }
-  
+
 export default IVolunteerPlatformSignup;


### PR DESCRIPTION
## Notion ticket link
[Create GetVolunteerSignup implementation logic](https://www.notion.so/uwblueprintexecs/Create-GetVolunteerSignup-implementation-logic-e91f67ed3e904abeacf0702baa2dedf6)


## Implementation description
* Implemented `getVolunteerPlatformSignup` logic with error catching
* Returns a list of volunteers that correspond to a passed in `adminId`

## What should reviewers focus on
* Correct Prisma logic

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
