### PR TITLE
Seed Dev Database With Users

### DIFF
--- a/backend/typescript/package.json
+++ b/backend/typescript/package.json
@@ -10,6 +10,9 @@
     "fix": "eslint . --ext .ts,.js --fix",
     "postinstall": "tsc"
   },
+  "prisma": {
+    "seed": "ts-node ./prisma/seed.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/backend/typescript/prisma/seed.ts
+++ b/backend/typescript/prisma/seed.ts
@@ -1,0 +1,48 @@
+import { Prisma, PrismaClient, Status } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const userPromises = [];
+
+  for (let i = 1; i <= 4; i++) {
+    const userNumber = i;
+    const randomUser: Prisma.userCreateInput = {
+      authId: `testVolunteer${userNumber}`,
+      email: `testVolunteer${userNumber}@gmail.com`,
+      firstName: `testVolunteerFirst${userNumber}`,
+      lastName: `testVolunteerLast${userNumber}`,
+      role: "VOLUNTEER",
+      isAccepted: Status.PENDING,
+    };
+
+    const userCreationPromise = prisma.user.create({
+      data: randomUser,
+    });
+    userPromises.push(userCreationPromise);
+  }
+  for (let i = 1; i <= 4; i++) {
+    const userNumber = i;
+    const randomUser: Prisma.userCreateInput = {
+      authId: `testAdmin${userNumber}`,
+      email: `testAdmin${userNumber}@gmail.com`,
+      firstName: `testAdminFirst${userNumber}`,
+      lastName: `testAdminLast${userNumber}`,
+      role: "ADMIN",
+      isAccepted: Status.PENDING,
+    };
+
+    const userCreationPromise = prisma.user.create({
+      data: randomUser,
+    });
+    userPromises.push(userCreationPromise);
+  }
+
+  await Promise.all(userPromises);
+}
+
+main()
+  .catch((e) => console.error(e))
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/typescript/prisma/seed.ts
+++ b/backend/typescript/prisma/seed.ts
@@ -21,6 +21,7 @@ async function main() {
     });
     userPromises.push(userCreationPromise);
   }
+
   for (let i = 1; i <= 4; i++) {
     const userNumber = i;
     const randomUser: Prisma.userCreateInput = {
@@ -30,6 +31,40 @@ async function main() {
       lastName: `testAdminLast${userNumber}`,
       role: "ADMIN",
       isAccepted: Status.PENDING,
+    };
+
+    const userCreationPromise = prisma.user.create({
+      data: randomUser,
+    });
+    userPromises.push(userCreationPromise);
+  }
+
+  for (let i = 1; i <= 2; i++) {
+    const userNumber = i;
+    const randomUser: Prisma.userCreateInput = {
+      authId: `testAdmin${userNumber}Accepted`,
+      email: `testAdmin${userNumber}Accepted@gmail.com`,
+      firstName: `testAdminFirst${userNumber}Accepted`,
+      lastName: `testAdminLast${userNumber}Accepted`,
+      role: "ADMIN",
+      isAccepted: Status.ACCEPTED,
+    };
+
+    const userCreationPromise = prisma.user.create({
+      data: randomUser,
+    });
+    userPromises.push(userCreationPromise);
+  }
+
+  for (let i = 1; i <= 2; i++) {
+    const userNumber = i;
+    const randomUser: Prisma.userCreateInput = {
+      authId: `testAdmin${userNumber}Accepted`,
+      email: `testAdmin${userNumber}Accepted@gmail.com`,
+      firstName: `testAdminFirst${userNumber}Accepted`,
+      lastName: `testAdminLast${userNumber}Accepted`,
+      role: "VOLUNTEER",
+      isAccepted: Status.ACCEPTED,
     };
 
     const userCreationPromise = prisma.user.create({


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Seed Dev Database with Fake Users](https://www.notion.so/uwblueprintexecs/Seed-Dev-Database-with-Fake-Users-ce14d41e8d5e4b29bf248d8fd4b1e7e7?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a seeding script that populates the development.user table with 4 volunteers and 4 admins
* User names/auths are generated by incrementing an index


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
How I ran the seeding script:
1. Go into our scv2_ts_backend docker container
2. Go to "Files" - ".env"
3. Open file editor
4. Change the "test" in the database URL to "development" to populate the development collection
5. Run the container
6. Go to "Exec"
7. Type in `npx prisma db seed -- --environment development`

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
