### PR TITLE
Create Secondary Signup Pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import React, { useState, useReducer } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import {ChakraProvider} from "@chakra-ui/react";
+import { ChakraProvider } from "@chakra-ui/react";
 
 import Login from "./components/auth/Login";
 import Signup from "./components/auth/Signup";
@@ -27,15 +27,16 @@ import EditTeamInfoPage from "./components/pages/EditTeamPage";
 import HooksDemo from "./components/pages/HooksDemo";
 
 import { AuthenticatedUser } from "./types/AuthTypes";
+import SignupEmergencyContact from "./components/auth/SignupEmergencyContact";
+import SignupSecondary from "./components/auth/SignupSecondary";
 
 const App = (): React.ReactElement => {
   const currentUser: AuthenticatedUser = getLocalStorageObj<AuthenticatedUser>(
     AUTHENTICATED_USER_KEY,
   );
 
-  const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser>(
-    currentUser,
-  );
+  const [authenticatedUser, setAuthenticatedUser] =
+    useState<AuthenticatedUser>(currentUser);
 
   // Some sort of global state. Context API replaces redux.
   // Split related states into different contexts as necessary.
@@ -54,54 +55,69 @@ const App = (): React.ReactElement => {
           value={{ authenticatedUser, setAuthenticatedUser }}
         >
           <ChakraProvider>
-          <Router>
-            <Switch>
-              <Route exact path={Routes.LOGIN_PAGE} component={Login} />
-              <Route exact path={Routes.SIGNUP_PAGE} component={Signup} />
-              <PrivateRoute exact path={Routes.HOME_PAGE} component={Default} />
-              <PrivateRoute
-                exact
-                path={Routes.CREATE_ENTITY_PAGE}
-                component={CreatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.UPDATE_ENTITY_PAGE}
-                component={UpdatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.DISPLAY_ENTITY_PAGE}
-                component={DisplayPage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.CREATE_SIMPLE_ENTITY_PAGE}
-                component={SimpleEntityCreatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.UPDATE_SIMPLE_ENTITY_PAGE}
-                component={SimpleEntityUpdatePage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.DISPLAY_SIMPLE_ENTITY_PAGE}
-                component={SimpleEntityDisplayPage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.EDIT_TEAM_PAGE}
-                component={EditTeamInfoPage}
-              />
-              <PrivateRoute
-                exact
-                path={Routes.HOOKS_PAGE}
-                component={HooksDemo}
-              />
-              <Route exact path="*" component={NotFound} />
-            </Switch>
-          </Router>
+            <Router>
+              <Switch>
+                <Route exact path={Routes.LOGIN_PAGE} component={Login} />
+                <Route exact path={Routes.SIGNUP_PAGE} component={Signup} />
+                <Route
+                  exact
+                  path={Routes.SIGNUP_SECONDARY}
+                  component={SignupSecondary}
+                />
+                <Route
+                  exact
+                  path={Routes.SIGNUP_EMERGENCY_CONTACT}
+                  component={SignupEmergencyContact}
+                />
+
+                <PrivateRoute
+                  exact
+                  path={Routes.HOME_PAGE}
+                  component={Default}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.CREATE_ENTITY_PAGE}
+                  component={CreatePage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.UPDATE_ENTITY_PAGE}
+                  component={UpdatePage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.DISPLAY_ENTITY_PAGE}
+                  component={DisplayPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.CREATE_SIMPLE_ENTITY_PAGE}
+                  component={SimpleEntityCreatePage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.UPDATE_SIMPLE_ENTITY_PAGE}
+                  component={SimpleEntityUpdatePage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.DISPLAY_SIMPLE_ENTITY_PAGE}
+                  component={SimpleEntityDisplayPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.EDIT_TEAM_PAGE}
+                  component={EditTeamInfoPage}
+                />
+                <PrivateRoute
+                  exact
+                  path={Routes.HOOKS_PAGE}
+                  component={HooksDemo}
+                />
+                <Route exact path="*" component={NotFound} />
+              </Switch>
+            </Router>
           </ChakraProvider>
         </AuthContext.Provider>
       </SampleContextDispatcherContext.Provider>

--- a/frontend/src/components/auth/SignupEmergencyContact.tsx
+++ b/frontend/src/components/auth/SignupEmergencyContact.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from "react";
+import { useHistory, Link as ReactRouterLink } from "react-router-dom";
+import {
+  Flex,
+  Box,
+  Center,
+  Heading,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Button,
+  Text,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import { validatePhoneNumber } from "../../utils/ValidationUtils";
+import { SIGNUP_SECONDARY } from "../../constants/Routes";
+
+const SignupEmergencyContact = () => {
+  const [emergencyFirstName, setEmergencyFisrtName] = useState("");
+  const [emergencyLastName, setEmergencyLastName] = useState("");
+  const [emergencyPhoneNumber, setEmergencyPhoneNumber] = useState("");
+  const [phoneNumberError, setPhoneNumberError] = useState("");
+
+  const history = useHistory();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  const onClickCreate = () => {
+    console.log("Emergency contact data:", {
+      emergencyFirstName,
+      emergencyLastName,
+      emergencyPhoneNumber,
+    });
+  };
+
+  const onBackClick = () => {
+    history.push(SIGNUP_SECONDARY);
+  };
+
+  const handlePhoneNumberChange = (value: string) => {
+    setEmergencyPhoneNumber(value);
+    const error = validatePhoneNumber(value);
+    setPhoneNumberError(error || "");
+  };
+
+  const isButtonDisabled =
+    !emergencyFirstName ||
+    !emergencyLastName ||
+    !emergencyPhoneNumber ||
+    !!phoneNumberError;
+
+  return (
+    <Flex
+      width="100vw"
+      height="100vh"
+      align="center"
+      justify="center"
+      background="dimgray"
+    >
+      <Box
+        width="md"
+        pt={16}
+        pr={16}
+        pl={16}
+        pb={10}
+        m={5}
+        background="white"
+        rounded={20}
+      >
+        <Box pb={4} textAlign="left">
+          <Heading size="lg">Create an Account</Heading>
+        </Box>
+        <Box my={4} textAlign="left">
+          <form onSubmit={handleSubmit}>
+            <FormControl mt={6} border={2} borderColor="#0B0B0B" isRequired>
+              <FormLabel>Emergency Contact First Name</FormLabel>
+              <Input
+                placeholder="First Name"
+                value={emergencyFirstName}
+                onChange={(event: {
+                  target: { value: React.SetStateAction<string> };
+                }) => setEmergencyFisrtName(event.target.value)}
+              />
+            </FormControl>
+            <FormControl mt={6} border={2} isRequired>
+              <FormLabel>Emergency Contact Last Name</FormLabel>
+              <Input
+                placeholder="Last Name"
+                value={emergencyLastName}
+                onChange={(event: {
+                  target: { value: React.SetStateAction<string> };
+                }) => setEmergencyLastName(event.target.value)}
+              />
+            </FormControl>
+            <FormControl
+              mt={6}
+              border={2}
+              borderColor={phoneNumberError ? "red.500" : "#0B0B0B"}
+              isRequired
+            >
+              <FormLabel>Emergency Contact Number</FormLabel>
+              <Input
+                placeholder="Number"
+                value={emergencyPhoneNumber}
+                onChange={(e: { target: { value: string } }) =>
+                  handlePhoneNumberChange(e.target.value)
+                }
+              />
+              {phoneNumberError && (
+                <FormHelperText fontSize="12" textAlign="right" color="red.500">
+                  {phoneNumberError}
+                </FormHelperText>
+              )}
+            </FormControl>
+
+            <Flex mt={4} mb={4} justify="space-between" w="100%">
+              <Button
+                mt={4}
+                mr={4}
+                w="35%"
+                color="white"
+                background="#28214C"
+                type="submit"
+                onClick={onBackClick}
+              >
+                Back
+              </Button>
+              <Button
+                w="61%"
+                mt={4}
+                color="white"
+                background="#28214C"
+                isDisabled={isButtonDisabled}
+                type="submit"
+                onClick={onClickCreate}
+              >
+                Create
+              </Button>
+            </Flex>
+
+            <Center>
+              <Text fontSize="sm">
+                Already have an account?{" "}
+                <ChakraLink
+                  as={ReactRouterLink}
+                  to="/login"
+                  textDecoration="underline"
+                >
+                  Login
+                </ChakraLink>
+              </Text>
+            </Center>
+          </form>
+        </Box>
+      </Box>
+    </Flex>
+  );
+};
+
+export default SignupEmergencyContact;

--- a/frontend/src/components/auth/SignupSecondary.tsx
+++ b/frontend/src/components/auth/SignupSecondary.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from "react";
+import { useHistory, Link as ReactRouterLink } from "react-router-dom";
+import {
+  Flex,
+  Box,
+  Center,
+  Heading,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Button,
+  Text,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import {
+  validateEmail,
+  validatePassword,
+  validatePhoneNumber,
+} from "../../utils/ValidationUtils";
+import { SIGNUP_PAGE, SIGNUP_EMERGENCY_CONTACT } from "../../constants/Routes";
+
+const SignupSecondary = (): React.ReactElement => {
+  const [email, setEmail] = useState("");
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [password, setPassword] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [phoneNumberError, setPhoneNumberError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const history = useHistory();
+
+  const isButtonDisabled =
+    !email ||
+    email !== confirmEmail ||
+    !password ||
+    !phoneNumber ||
+    !!emailError ||
+    !!phoneNumberError ||
+    !!passwordError;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  const onNextClick = () => {
+    console.log("Signup Info:", {
+      email,
+      phoneNumber,
+    });
+    history.push(SIGNUP_EMERGENCY_CONTACT);
+  };
+
+  const onBackClick = () => {
+    history.push(SIGNUP_PAGE);
+  };
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value);
+    const error = validateEmail(value);
+    setEmailError(error || "");
+  };
+
+  const handlePhoneNumberChange = (value: string) => {
+    setPhoneNumber(value);
+    const error = validatePhoneNumber(value);
+    setPhoneNumberError(error || "");
+  };
+
+  const handlePasswordChange = (value: string) => {
+    setPassword(value);
+    const error = validatePassword(value);
+    setPasswordError(error || "");
+  };
+
+  return (
+    <Flex
+      width="100vw"
+      height="100vh"
+      align="center"
+      justify="center"
+      background="dimgray"
+    >
+      <Box
+        width="md"
+        pt={16}
+        pr={16}
+        pl={16}
+        pb={10}
+        m={5}
+        background="white"
+        rounded={20}
+      >
+        <Box pb={4} textAlign="left">
+          <Heading size="lg">Create an Account</Heading>
+        </Box>
+        <Box my={4} textAlign="left">
+          <form onSubmit={handleSubmit}>
+            <FormControl
+              border={2}
+              borderColor={emailError ? "red.500" : "#0B0B0B"}
+              isRequired
+            >
+              <FormLabel>E-mail</FormLabel>
+              <Input
+                type="email"
+                placeholder="E-mail"
+                value={email}
+                onChange={(e: { target: { value: string } }) =>
+                  handleEmailChange(e.target.value)
+                }
+              />
+              {emailError && (
+                <FormHelperText fontSize="12" textAlign="right" color="red.500">
+                  {emailError}
+                </FormHelperText>
+              )}
+            </FormControl>
+            <FormControl
+              mt={4}
+              border={2}
+              borderColor={confirmEmail !== email ? "red.500" : "#0B0B0B"}
+              isRequired
+            >
+              <FormLabel>Confirm E-mail</FormLabel>
+              <Input
+                type="email"
+                placeholder="E-mail"
+                value={confirmEmail}
+                onChange={(event: {
+                  target: { value: React.SetStateAction<string> };
+                }) => setConfirmEmail(event.target.value)}
+              />
+              {confirmEmail !== email && (
+                <FormHelperText fontSize="12" textAlign="right" color="red.500">
+                  Email addresses do not match
+                </FormHelperText>
+              )}
+            </FormControl>
+            <FormControl
+              mt={4}
+              border={2}
+              borderColor={phoneNumberError ? "red.500" : "#0B0B0B"}
+              isRequired
+            >
+              <FormLabel>Phone Number</FormLabel>
+              <Input
+                type="tel"
+                placeholder="Number"
+                value={phoneNumber}
+                onChange={(e: { target: { value: string } }) =>
+                  handlePhoneNumberChange(e.target.value)
+                }
+              />
+              {phoneNumberError && (
+                <FormHelperText fontSize="12" textAlign="right" color="red.500">
+                  {phoneNumberError}
+                </FormHelperText>
+              )}
+            </FormControl>
+            <FormControl
+              mt={4}
+              border={2}
+              borderColor={passwordError ? "red.500" : "#0B0B0B"}
+              isRequired
+            >
+              <FormLabel>Password</FormLabel>
+              <Input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e: { target: { value: string } }) =>
+                  handlePasswordChange(e.target.value)
+                }
+              />
+              <FormHelperText
+                fontSize="12"
+                textAlign="right"
+                color={passwordError ? "red.500" : "grey"}
+              >
+                Must include 1 letter, 1 number and 8 characters
+              </FormHelperText>
+            </FormControl>
+
+            <Flex mt={4} mb={4} justify="space-between" w="100%">
+              <Button
+                mt={4}
+                mr={4}
+                w="35%"
+                color="white"
+                background="#28214C"
+                type="submit"
+                onClick={onBackClick}
+              >
+                Back
+              </Button>
+              <Button
+                w="61%"
+                mt={4}
+                color="white"
+                background="#28214C"
+                isDisabled={isButtonDisabled}
+                type="submit"
+                onClick={onNextClick}
+              >
+                Next
+              </Button>
+            </Flex>
+
+            <Center>
+              <Text fontSize="sm">
+                Already have an account?{" "}
+                <ChakraLink
+                  as={ReactRouterLink}
+                  to="/login"
+                  textDecoration="underline"
+                >
+                  Login
+                </ChakraLink>
+              </Text>
+            </Center>
+          </form>
+        </Box>
+      </Box>
+    </Flex>
+  );
+};
+
+export default SignupSecondary;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -4,6 +4,10 @@ export const LOGIN_PAGE = "/login";
 
 export const SIGNUP_PAGE = "/signup";
 
+export const SIGNUP_SECONDARY = "/signup/more-info";
+
+export const SIGNUP_EMERGENCY_CONTACT = "/signup/emergency-contact";
+
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const DISPLAY_ENTITY_PAGE = "/entity";

--- a/frontend/src/utils/ValidationUtils.ts
+++ b/frontend/src/utils/ValidationUtils.ts
@@ -1,5 +1,5 @@
 export const validatePhoneNumber = (value: string): string | null => {
-  const phoneNumberRegex = /^\d+$/;
+  const phoneNumberRegex = /^\d{10}$/;
   return phoneNumberRegex.test(value) ? null : "Invalid number";
 };
 

--- a/frontend/src/utils/ValidationUtils.ts
+++ b/frontend/src/utils/ValidationUtils.ts
@@ -1,0 +1,24 @@
+export const validatePhoneNumber = (value: string): string | null => {
+  const phoneNumberRegex = /^\d+$/;
+  return phoneNumberRegex.test(value) ? null : "Invalid number";
+};
+
+export const validateEmail = (value: string): string | null => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(value) ? null : "Invalid address";
+};
+
+export const validatePassword = (value: string): string | null => {
+  const letterRegex = /[a-zA-Z]/;
+  const numberRegex = /[0-9]/;
+
+  if (
+    value.length < 8 ||
+    !letterRegex.test(value) ||
+    !numberRegex.test(value)
+  ) {
+    return "Password must contain at least 1 letter, 1 number, and be at least 8 characters long";
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Sign up Secondary Component](https://www.notion.so/uwblueprintexecs/Sign-up-Secondary-Component-e2d6f23b264e41b4b8283e29e8d4f484)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
*  create a secondary and emergency contact sign up page based on the Figma design using Chakra UI
* create routes that redirects user 
* validate phone numbers, emails and passwords
* console log user info


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. check out signup/more-info and fill information 
2. try passing in invalid emails, phone numbers and passwords -> invalid state should appear 
3. click next to go to emergency contact page
4. try passing an invalid phone number -> invalid state should appear 
5. go back to the secondary component page 
6. check out console for user info 
7. designs should match Figma 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* design matches Figma and is consistent 
* validation works as needed
* redirect links work
* user info is printed out correctly  
* code is clean 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
