### PR TITLE
Timestamp all records

### DIFF
--- a/backend/typescript/prisma/platformSignupsSeed.ts
+++ b/backend/typescript/prisma/platformSignupsSeed.ts
@@ -19,6 +19,7 @@ async function main() {
       firstName: user.firstName,
       lastName: user.lastName,
       status: Status.PENDING,
+      createdAt: new Date().toISOString(),
     });
   });
 

--- a/backend/typescript/prisma/schema.prisma
+++ b/backend/typescript/prisma/schema.prisma
@@ -24,6 +24,7 @@ model user {
   role                 Role
   isAccepted           Status
   serviceRequests      serviceRequest[] // for volunteer
+  createdAt            String?
 }
 
 model serviceRequest {
@@ -38,6 +39,7 @@ model serviceRequest {
   cookingMethod String?
   frequency     String?
   requestType   ServiceRequestType
+  createdAt     String?
 }
 
 model platformSignUp {
@@ -46,6 +48,7 @@ model platformSignUp {
   firstName String
   lastName  String
   status    Status
+  createdAt String?
 }
 
 enum Role {

--- a/backend/typescript/prisma/userSeed.ts
+++ b/backend/typescript/prisma/userSeed.ts
@@ -31,6 +31,7 @@ async function main() {
       lastName: `testVolunteerLast${userNumber}`,
       role: "VOLUNTEER",
       isAccepted: Status.PENDING,
+      createdAt: new Date().toISOString(),
     };
 
     const userCreationPromise = prisma.user.create({
@@ -54,6 +55,7 @@ async function main() {
       lastName: `testAdminLast${userNumber}`,
       role: "ADMIN",
       isAccepted: Status.PENDING,
+      createdAt: new Date().toISOString(),
     };
 
     const userCreationPromise = prisma.user.create({
@@ -77,6 +79,7 @@ async function main() {
       lastName: `testVolunteerLast${userNumber}Accepted`,
       role: "VOLUNTEER",
       isAccepted: Status.ACCEPTED,
+      createdAt: new Date().toISOString(),
     };
 
     const userCreationPromise = prisma.user.create({
@@ -100,6 +103,7 @@ async function main() {
       lastName: `testAdminLast${userNumber}Accepted`,
       role: "ADMIN",
       isAccepted: Status.ACCEPTED,
+      createdAt: new Date().toISOString(),
     };
 
     const userCreationPromise = prisma.user.create({

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -68,6 +68,7 @@ authRouter.post("/register", registerRequestValidator, async (req, res) => {
       lastName: req.body.lastName,
       email: req.body.email,
       status: Status.PENDING,
+      createdAt: new Date().toISOString(),
     };
 
     await platformSignup.postPlatformSignup(newPlatformSignUp);

--- a/backend/typescript/services/implementations/platformSignup.ts
+++ b/backend/typescript/services/implementations/platformSignup.ts
@@ -1,77 +1,77 @@
 /* eslint-disable class-methods-use-this */
 import { platformSignUp, Status } from "@prisma/client";
 import prisma from "../../prisma";
-import IPlatformSignup, { postPlatformSignupInput } from "../interfaces/platformSignup";
+import IPlatformSignup, {
+  postPlatformSignupInput,
+} from "../interfaces/platformSignup";
 import logger from "../../utilities/logger";
 import { getErrorMessage } from "../../utilities/errorUtils";
 
 const Logger = logger(__filename);
 
 class PlatformSignup implements IPlatformSignup {
-  async getPlatformSignups(
-  ): Promise<platformSignUp[]> {
+  async getPlatformSignups(): Promise<platformSignUp[]> {
     let signUps: platformSignUp[];
     try {
       signUps = await prisma.platformSignUp.findMany();
     } catch (error) {
       Logger.error(
-        `Failed to get platform signups. Reason = ${getErrorMessage(
-          error,
-        )}`,
+        `Failed to get platform signups. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
     return signUps;
   }
 
-
-  async postPlatformSignup(platform: postPlatformSignupInput,): Promise<platformSignUp> {
-  let newPlatformSignup: platformSignUp;
+  async postPlatformSignup(
+    platform: postPlatformSignupInput,
+  ): Promise<platformSignUp> {
+    let newPlatformSignup: platformSignUp;
 
     try {
-        // Check for duplicate email
-        const emailUsed = await prisma.platformSignUp.findFirst({
-          where: {
-              email: platform.email,
-          },
-        });
+      // Check for duplicate email
+      const emailUsed = await prisma.platformSignUp.findFirst({
+        where: {
+          email: platform.email,
+        },
+      });
 
-        if (emailUsed) {
-            throw new Error("The email provided is already in use.");
-        }
+      if (emailUsed) {
+        throw new Error("The email provided is already in use.");
+      }
 
-        newPlatformSignup = await prisma.platformSignUp.create({
-            data: platform,
-        });
+      newPlatformSignup = await prisma.platformSignUp.create({
+        data: platform,
+      });
     } catch (error: unknown) {
-        Logger.error(
-            `Failed to create platform signup. Reason = ${getErrorMessage(error)}`
-        );
-        throw error;
+      Logger.error(
+        `Failed to create platform signup. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
     }
 
     return newPlatformSignup;
-}
+  }
 
-  async editPlatformSignup(signupId:string): Promise<void> {
-    try{
-          const entryToDelete = await prisma.platformSignUp.findUnique({
-                where: { id: signupId },
-                });
+  async editPlatformSignup(signupId: string): Promise<void> {
+    try {
+      const entryToDelete = await prisma.platformSignUp.findUnique({
+        where: { id: signupId },
+      });
 
-            if(entryToDelete){
-                const deleteUserResult = await prisma.platformSignUp.delete({
-                    where: { id: signupId },
-                  });
-
-            } else {
-                throw new Error(` Signup with ID ${signupId} not found.`);
-            }
-            
-        } catch (error: unknown) {
-            console.error(`Failed to delete Signup. Reason = ${getErrorMessage(error)}`)
-            throw error;
-        }
+      if (entryToDelete) {
+        const deleteUserResult = await prisma.platformSignUp.delete({
+          where: { id: signupId },
+        });
+      } else {
+        throw new Error(` Signup with ID ${signupId} not found.`);
+      }
+    } catch (error: unknown) {
+      console.error(
+        `Failed to delete Signup. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
   }
 
   async acceptById(signupRequestId: string): Promise<void> {
@@ -90,15 +90,11 @@ class PlatformSignup implements IPlatformSignup {
         where: { id: signupRequestId },
         data: { status: Status.ACCEPTED },
       });
-
-    } catch(error: unknown) {
-      Logger.error(
-        `Failed to accept. Reason = ${getErrorMessage(error)}`
-      );
+    } catch (error: unknown) {
+      Logger.error(`Failed to accept. Reason = ${getErrorMessage(error)}`);
       throw error;
     }
   }
-
 }
 
 export default PlatformSignup;

--- a/backend/typescript/services/implementations/serviceRequest.ts
+++ b/backend/typescript/services/implementations/serviceRequest.ts
@@ -41,13 +41,10 @@ class ServiceRequest implements IServiceRequest {
     }
   }
 
-  async postServiceRequest(
-    inputServiceRequest: any,
-  ): Promise<serviceRequest> {
+  async postServiceRequest(inputServiceRequest: any): Promise<serviceRequest> {
     let newServiceRequest: serviceRequest;
     try {
-      
-      const requesterId = inputServiceRequest.requesterId;
+      const { requesterId } = inputServiceRequest;
 
       if (!requesterId) {
         throw new Error("Only existing users can create service requests.");
@@ -58,10 +55,13 @@ class ServiceRequest implements IServiceRequest {
           id: requesterId,
         },
       });
-      
+
       if (!userExists) {
         throw new Error("Only existing users can create service requests.");
-      } else if (userExists.role != "ADMIN" || userExists.isAccepted != "ACCEPTED") {
+      } else if (
+        userExists.role != "ADMIN" ||
+        userExists.isAccepted != "ACCEPTED"
+      ) {
         throw new Error("Only admins can create service requests.");
       }
 

--- a/backend/typescript/services/implementations/serviceRequest.ts
+++ b/backend/typescript/services/implementations/serviceRequest.ts
@@ -65,7 +65,10 @@ class ServiceRequest implements IServiceRequest {
         throw new Error("Only admins can create service requests.");
       }
 
-      const requestData: Prisma.serviceRequestCreateInput = inputServiceRequest;
+      const requestData: Prisma.serviceRequestCreateInput = {
+        ...inputServiceRequest,
+        createdAt: new Date().toISOString(),
+      };
       newServiceRequest = await prisma.serviceRequest.create({
         data: requestData,
       });

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -12,7 +12,7 @@ const Logger = logger(__filename);
 const getPrismaUserByAuthId = async (authId: string): Promise<user> => {
   const user = await prisma.user.findFirst({
     where: {
-      authId: authId,
+      authId,
     },
   });
   if (!user) {

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -202,6 +202,7 @@ class UserService implements IUserService {
             emergencyPhoneNumber: user.emergencyPhoneNumber,
             role: user.role,
             isAccepted: Status.PENDING,
+            createdAt: new Date().toISOString(),
           },
         });
       } catch (prismaError) {
@@ -342,6 +343,7 @@ class UserService implements IUserService {
               emergencyPhoneNumber: deletedUser.emergencyPhoneNumber,
               role: deletedUser.role,
               isAccepted: Status.PENDING,
+              createdAt: deletedUser.createdAt,
             },
           });
         } catch (prismaError: unknown) {
@@ -402,6 +404,7 @@ class UserService implements IUserService {
               emergencyPhoneNumber: userToDelete.emergencyPhoneNumber,
               role: userToDelete.role,
               isAccepted: Status.PENDING,
+              createdAt: userToDelete.createdAt,
             },
           });
         } catch (prismaError: unknown) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Timestamp all records](https://www.notion.so/uwblueprintexecs/Timestamp-all-records-ac4d138586864fe5a9f89d84f2dee96c?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Modify all models to include createdAt field
* Add createdAt field to all POST requests
* Use the ISO string method on current date to get the current date in ISO string

**Important**: please see screenshots in Notion

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to localhost:3000/signup
2. Create a new user
3. Check in MongoDB -> test -> user -> user is created with createdAt field populated
4. Check in MongoDB -> test -> user -> platform sign up is created with createdAt field populated
5. Send POST request to create service request
6. Response should contain createdAt field populated


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* User and platform sign up records should have createdAt fields populated
* ServiceRequest records should have createdAt fields populated in Postman
* createdAt field should be UTC date in ISODate format


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
