### PR TITLE
Add filtering to getServiceRequest Route

### DIFF
--- a/backend/typescript/rest/serviceRequestRoutes.ts
+++ b/backend/typescript/rest/serviceRequestRoutes.ts
@@ -9,7 +9,7 @@ const serviceRequestService: IServiceRequest = new ServiceRequest();
 
 /* Get service request by ID if requestId is specified; otherwise, return all service requests. */
 serviceRequestRouter.get("/", async (req, res) => {
-  const { requestId } = req.query;
+  const { requestId, fromDate, toDate } = req.body;
 
   if (requestId) {
     if (typeof requestId !== "string") {
@@ -28,7 +28,32 @@ serviceRequestRouter.get("/", async (req, res) => {
     }
   } else {
     try {
-      const serviceRequests = await serviceRequestService.getServiceRequests();
+
+      let serviceRequests;
+
+      if (fromDate && toDate) {
+        const fromDateFormatted = new Date(fromDate as string).toISOString();
+        const toDateFormatted = new Date(toDate as string).toISOString();
+
+        if (isNaN(new Date(fromDateFormatted).getTime()) || isNaN(new Date(toDateFormatted).getTime())) {
+          res
+            .status(400)
+            .json({ error: "fromDate and toDate query parameters must be valid dates in ISO format." });
+          return;
+        }
+
+        serviceRequests = await serviceRequestService.getServiceRequests();
+        serviceRequests = serviceRequests.filter(request => {
+          const requestDate = request.shiftTime ? new Date(request.shiftTime).toISOString() : null;
+          if (requestDate) {
+            return requestDate >= fromDateFormatted && requestDate <= toDateFormatted;
+          }
+          return false;
+        });
+      } else {
+        serviceRequests = await serviceRequestService.getServiceRequests();
+      }
+
       res.status(200).json(serviceRequests);
     } catch (error: unknown) {
       res.status(500).json({ error: getErrorMessage(error) });


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add filtering to GET serviceRequest](https://www.notion.so/uwblueprintexecs/Add-filtering-to-GET-serviceRequest-f0c41445947c49f09ae9887fbdc14fd1?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added date filtering to the existing get serviceRequest route
* If fromDate and toDate are not provided, all the serviceRequests are still returned
* If a serviceRequest ID is provided, that specific request is returned


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test on postman


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Focus on ISODate conversions


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
