### PR TITLE
show volunteer dashboard with mock data

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/src/components/pages/Shifts.tsx
+++ b/frontend/src/components/pages/Shifts.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Box, Heading, Text } from "@chakra-ui/react";
 import ShiftCard from "../common/ShiftCard";
-import { ServiceRequest } from "../../types/ServiceRequestTypes";
+import {
+  ServiceRequest,
+  ServiceRequestType,
+} from "../../types/ServiceRequestTypes";
 import ServiceRequestAPIClient from "../../APIClients/ServiceRequestAPIClient";
 
 type DateShifts = {
@@ -64,11 +67,59 @@ const Shifts = (): React.ReactElement => {
   };
 
   useEffect(() => {
-    const fetchShifts = async () => {
-      const data = await ServiceRequestAPIClient.get();
-      setShiftsByDate(groupByDate(data));
-    };
-    fetchShifts();
+    const mockData: ServiceRequest[] = [
+      {
+        id: "1",
+        requestName: "Morning Shift",
+        requesterId: "req1",
+        location: "Site A",
+        shiftTime: new Date().toISOString(),
+        shiftEndTime: new Date(
+          new Date().getTime() + 2 * 60 * 60 * 1000,
+        ).toISOString(),
+        description: "This is a morning shift at Site A.",
+        meal: "Breakfast",
+        cookingMethod: "Grill",
+        frequency: "Daily",
+        requestType: ServiceRequestType.SITE,
+      },
+      {
+        id: "2",
+        requestName: "Afternoon Shift",
+        requesterId: "req2",
+        location: "Kitchen B",
+        shiftTime: new Date(
+          new Date().getTime() + 4 * 60 * 60 * 1000,
+        ).toISOString(),
+        shiftEndTime: new Date(
+          new Date().getTime() + 6 * 60 * 60 * 1000,
+        ).toISOString(),
+        description: "This is an afternoon shift at Kitchen B.",
+        meal: "Lunch",
+        cookingMethod: "Boil",
+        frequency: "Weekly",
+        requestType: ServiceRequestType.KITCHEN,
+      },
+      {
+        id: "3",
+        requestName: "Evening Shift",
+        requesterId: "req3",
+        location: "Site C",
+        shiftTime: new Date(
+          new Date().getTime() + 8 * 60 * 60 * 1000,
+        ).toISOString(),
+        shiftEndTime: new Date(
+          new Date().getTime() + 10 * 60 * 60 * 1000,
+        ).toISOString(),
+        description: "This is an evening shift at Site C.",
+        meal: "Dinner",
+        cookingMethod: "Bake",
+        frequency: "Monthly",
+        requestType: ServiceRequestType.SITE,
+      },
+    ];
+
+    setShiftsByDate(groupByDate(mockData));
   }, []);
 
   return (

--- a/frontend/src/components/pages/VolunteerDashboard.tsx
+++ b/frontend/src/components/pages/VolunteerDashboard.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Flex, Box, Heading } from '@chakra-ui/react';
+import { Flex, Box, Heading } from "@chakra-ui/react";
 import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
+import CustomizedCalendar from "./Calendar/CustomizedCalendar";
+import Shifts from "./Shifts";
 
 const VolunteerDashboard = (): React.ReactElement => {
-  const [userInfo, setUserInfo] = useState<any>(null); 
+  const [userInfo, setUserInfo] = useState<any>(null);
 
   useEffect(() => {
     const userData = localStorage.getItem(AUTHENTICATED_USER_KEY);
@@ -21,16 +23,16 @@ const VolunteerDashboard = (): React.ReactElement => {
       {/* Navbar Component Here */}
 
       <Flex bg="gray.100" pl={8} align="center" h="72px">
-        <Heading size='md'>Temp Navbar</Heading>
+        <Heading size="md">Temp Navbar</Heading>
       </Flex>
 
       <Flex flex="1">
-        <Box w="23%" pt={10} pl={8} border='1px' borderColor='gray.100'>
-          <Heading size='md'>Your Shifts</Heading>
+        <Box pt={10} pl={8} border="1px" borderColor="gray.100">
+          <Shifts />
         </Box>
 
-        <Box flex="1" pt={10} pl={6} border='1px' borderColor='gray.100'>
-          <Heading size='md'>Month, Year</Heading>
+        <Box flex="1" pt={10} pl={6} border="1px" borderColor="gray.100">
+          <CustomizedCalendar />
         </Box>
       </Flex>
     </Flex>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "abtc",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Implement the list view and calendar view onto the volunteer dashboard](https://www.notion.so/uwblueprintexecs/Implement-the-list-view-and-calendar-view-onto-the-volunteer-dashboard-d15e1eac6abc46dbbe57964fde67525a?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add mock data for Shifts 
* Get the UI for Shifts and the CustomizedCalendar in the volunteer dashboard to appear side by side, as given in the figma 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visually looking at the UI should do the job at localhost:3000/volunteer-dashboard
<img width="1430" alt="Screenshot 2024-06-11 at 7 06 14 PM" src="https://github.com/uwblueprint/abtc/assets/40416716/ec6f94be-c62d-438e-83e6-4db0663e78d5">

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
